### PR TITLE
Give greater flexibility on images and subnets filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,26 @@ platforms:
   - name: ubuntu-14.04
     driver:
       image_search:
-        owner-id: "099720109477"
-        name: ubuntu/images/*/ubuntu-*-14.04*
+        filters:
+          owner-id: "099720109477"
+          name: ubuntu/images/*/ubuntu-*-14.04*
+```
+
+More specific filters can also be used:
+
+```yaml
+platforms:
+  - name: ubuntu-14.04
+    driver:
+      image_search:
+
+        filters: # describe-images "filters" API
+          name: "debian-10-amd64-*"
+          tag:Name: "foobar"
+
+        owners: # describe-images "owners" API
+          - self
+          - "136693071363"
 ```
 
 In the event that there are multiple matches (as sometimes happens), we sort to
@@ -266,8 +284,9 @@ The default is unset, or `nil`.
 An example of usage:
 ```yaml
 subnet_filter:
-  tag:   'Name'
-  value: 'example-subnet-name'
+  filters:
+    tag:Name: 'example-subnet-name'
+    mapPublicIpOnLaunch: 'true'
 ```
 
 #### `tags`

--- a/lib/kitchen/driver/aws/instance_generator.rb
+++ b/lib/kitchen/driver/aws/instance_generator.rb
@@ -47,12 +47,12 @@ module Kitchen
           if config[:subnet_id].nil? && config[:subnet_filter]
             config[:subnet_id] = ::Aws::EC2::Client
               .new(region: config[:region]).describe_subnets(
-                filters: [
+                filters: config[:subnet_filter].fetch(:filters, {}).map do |key, value|
                   {
-                    name: "tag:#{config[:subnet_filter][:tag]}",
-                    values: [config[:subnet_filter][:value]],
-                  },
-                ]
+                    name: key,
+                    values: [value],
+                  }
+                end
               )[0][0].subnet_id
 
             if config[:subnet_id].nil?

--- a/lib/kitchen/driver/aws/standard_platform.rb
+++ b/lib/kitchen/driver/aws/standard_platform.rb
@@ -97,12 +97,13 @@ module Kitchen
         def find_image(image_search)
           driver.debug("Searching for images matching #{image_search} ...")
           # Convert to ec2 search format (pairs of name+values)
-          filters = image_search.map do |key, value|
-            { name: key.to_s, values: Array(value).map(&:to_s) }
+          filters = image_search
+          filters[:filters] = image_search.fetch(:filters, {}).map do |key, value|
+            {name: key, values: [value]}
           end
 
           # We prefer most recent first
-          images = driver.ec2.resource.images(filters: filters)
+          images = driver.ec2.resource.images(filters)
           images = sort_images(images)
           show_returned_images(images)
 

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -790,7 +790,7 @@ module Kitchen
                      {name: key, values: [value]}
                    end
                    subnets = ec2.client.describe_subnets(filters: filters).subnets
-                   raise "Subnets with tag '#{config[:subnet_filter][:tag]}=#{config[:subnet_filter][:value]}' not found during security group creation" if subnets.empty?
+                   raise "Subnets with filters: '#{filters}' not found during security group creation" if subnets.empty?
                    subnets.first.vpc_id
                  else
                    # Try to check for a default VPC.

--- a/lib/kitchen/driver/ec2.rb
+++ b/lib/kitchen/driver/ec2.rb
@@ -786,7 +786,10 @@ module Kitchen
 
                    subnets.first.vpc_id
                  elsif config[:subnet_filter]
-                   subnets = ec2.client.describe_subnets(filters: [{ name: "tag:#{config[:subnet_filter][:tag]}", values: [config[:subnet_filter][:value]] }]).subnets
+                   filters = config[:subnet_filter].fetch(:filters, {}).map do |key, value|
+                     {name: key, values: [value]}
+                   end
+                   subnets = ec2.client.describe_subnets(filters: filters).subnets
                    raise "Subnets with tag '#{config[:subnet_filter][:tag]}=#{config[:subnet_filter][:value]}' not found during security group creation" if subnets.empty?
                    subnets.first.vpc_id
                  else


### PR DESCRIPTION
Kitchen doesn't support filtering the source AMI and initial subnet like Packer's `source_ami_filter` and `subnet_filter` options do.

This completely breaks the current configuration format of Kitchen EC2 v3.2.0 but this also gives much more possibilities on how to filters the AMI and subnet.

I'll open an issue upstream to see if that could be accepted there, see https://github.com/test-kitchen/kitchen-ec2/issues/476.